### PR TITLE
Moar .gitignore items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 keys.yml
 /login*.sh
 *.retry
+kubeconfig.conf
+.venv


### PR DESCRIPTION
- kubeconfig.conf file that gets generated
- .venv/* (conventional naming for virtualenvs)