### PR TITLE
Invert the privilege escalation model

### DIFF
--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -1,6 +1,5 @@
 - name: Wait for instances to finish booting
   connection: local
-  become: no
   wait_for:
     host="{{ansible_ssh_host|default(inventory_hostname)}}"
     search_regex=OpenSSH
@@ -12,33 +11,30 @@
   setup:
     filter: "ansible_*"
 
-#- name: debug stuff
-#  vars:
-#    msg: |
-#           HOST Variables ("hostvars"):
-#           --------------------------------
-#           {{ hostvars | to_nice_json }}
-#  debug:
-#    msg: "{{ msg.split('\n') }}"
-
 - name: build hosts file
+  become: yes
   lineinfile: dest=/etc/hosts regexp='^{{ hostvars[item].ansible_default_ipv4.address }}.*$' line="{{ hostvars[item].ansible_default_ipv4.address }} {{ hostvars[item].ansible_hostname }} {{ hostvars[item].ansible_nodename }}" state=present
   when: hostvars[item].ansible_default_ipv4.address is defined
   with_items: "{{ groups['cluster'] }}"
 
 - name: disable selinux
+  become: yes
   selinux: state=disabled
 
 - name: disable of selinux - now
+  become: yes
   command: setenforce 0
 
-- name: Ensure net.bridge.bridge-nf-call-iptables is set. See kubeadm
+- name: Ensure net.bridge.bridge-nf-call-iptables is set
+  become: yes
   copy: src=k8s.conf owner=root group=root dest=/etc/sysctl.d/k8s.conf
 
 - name: Run sysctl
+  become: yes
   command: sysctl --system
 
 - name: Add Kubernetes yum repo
+  become: yes
   yum_repository:
     name: kubernetes
     description: Kubernetes kubeadm
@@ -47,6 +43,7 @@
     gpgcheck: yes
 
 - name: install utility programs
+  become: yes
   yum:
     disable_gpg_check: yes
     state: present
@@ -67,6 +64,7 @@
       - kernel-headers
 
 - name: install epel utility programs
+  become: yes
   yum:
     state: present
     disable_gpg_check: yes
@@ -77,6 +75,7 @@
       - device-mapper-persistent-data
 
 - name: remove all old docker packages
+  become: yes
   yum:
     state: removed
     disable_gpg_check: yes
@@ -91,12 +90,15 @@
       - docker-engine
 
 - name: install docker ce yum repo
+  become: yes
   command: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 
 - name: install docker ce
+  become: yes
   yum: name=docker-ce state=present disable_gpg_check=yes
 
 - name: enable kube services
+  become: yes
   service: name={{ item }} state=started enabled=yes
   with_items:
     - docker
@@ -104,6 +106,7 @@
     - kubelet
 
 - name: add centos to docker group
+  become: yes
   user:
     name: centos
     append: yes
@@ -118,15 +121,18 @@
     dest: /home/centos/crictl.tar.gz
 
 - name: install crictl
+  become: yes
   unarchive:
     src: /home/centos/crictl.tar.gz
     remote_src: yes
     dest: /bin
 
 - name: turn off swap
+  become: yes
   command: swapoff -a
 
 - name: remove swap from /etc/fstab
+  become: yes
   lineinfile:
     path: /etc/fstab
     state: absent

--- a/roles/devstack/tasks/main.yml
+++ b/roles/devstack/tasks/main.yml
@@ -1,43 +1,49 @@
 ---
 # tasks file for devstack
 - name: Install git
+  become: yes
   yum:
     name: git
     state: latest
-  become: true
+
 - name: Create /opt/stack
+  become: yes
   file: path=/opt/stack
         state=directory
         owner={{ansible_env.USER}}
         group={{ansible_env.USER}}
-  become: true
+
 - name: Clone devstack
-  git: repo=https://git.openstack.org/openstack-dev/devstack
+  git: repo=https://opendev.org/openstack-dev/devstack
        dest={{ansible_env.HOME}}/devstack
        update=no
+
 - name: Install ~/devstack/local.conf
   copy: dest={{ansible_env.HOME}}/devstack/local.conf
         src=local.conf
         mode=0644
         owner={{ansible_env.USER}}
+
 # The CentOS python-setuptools is too old
 # for devstack and it will use its own version
 # of setuptools
 - name: uninstall OS python-setuptools
-  become: true
+  become: yes
   package:
     name: python-setuptools
     state: absent
+
 - name: run stack.sh to deploy manila
   command: ./stack.sh
   args:
     chdir: /home/centos/devstack
     creates: /opt/stack/manila
+
 # But we need a system-wide setuptools for
 # python-manilclient pbr to work so re-install
 # it now that devstack stack.sh has completed
 - name: Re-install OS python-setuptools
-  become: true
+  become: yes
   package:
     name: python-setuptools
     state: present

--- a/roles/master/tasks/main.yml
+++ b/roles/master/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: add Mercurial yum repo
+  become: yes
   yum_repository:
     name: mercurial.selenic.com
     description: Mercurial
@@ -6,6 +7,7 @@
     gpgcheck: no
 
 - name: install dev programs to compile cloud-provider-openstack
+  become: yes
   yum:
     disable_gpg_check: yes
     state: present
@@ -19,19 +21,16 @@
       - python-pip
 
 - name: ensure go module source directories exist
-  become: no
   file:
     path: /home/centos/go/src
     state: directory
 
 - name: check if docker cephfs image exists
-  become: no
   command: docker image inspect quay.io/cephcsi/cephfsplugin:v1.0.0
   register: docker_cephfs_image_exists
   ignore_errors: yes
 
 - name: make the cephfs image and push it to the local registry
-  become: no
   shell: |
     source /etc/profile.d/golang.sh
     go get -d github.com/ceph/ceph-csi
@@ -41,13 +40,11 @@
   when: docker_cephfs_image_exists is failed
 
 - name: check if openstack-cloud-provider repository has been cloned
-  become: no
   stat:
     path: /home/centos/go/src/k8s.io/cloud-provider-openstack
   register: cloud_provider_openstack_repo
 
 - name: get the openstack-cloud-provider repository
-  become: no
   git:
     repo: 'https://github.com/kubernetes/cloud-provider-openstack'
     dest: /home/centos/go/src/k8s.io/cloud-provider-openstack
@@ -56,13 +53,11 @@
   when: not (cloud_provider_openstack_repo.stat.exists and cloud_provider_openstack_repo.stat.isdir)
 
 - name: check if docker manila-csi image exists
-  become: no
   command: docker image inspect k8scloudprovider/manila-csi-plugin
   register: docker_manila_csi_image_exists
   ignore_errors: yes
 
 - name: make the manila-csi image and push it to the local registry
-  become: no
   shell: |
     cd /home/centos/
     source /etc/profile.d/golang.sh
@@ -73,6 +68,7 @@
   when: docker_manila_csi_image_exists is failed
 
 - name: initialize kubeadm on master
+  become: yes
   shell: |
     kubeadm init --pod-network-cidr=10.244.0.0/16 \
         --token={{kubernetes_token }} \
@@ -82,17 +78,18 @@
     creates: /etc/kubernetes/manifests/kube-apiserver.yaml
 
 - name: create flannel network
+  become: yes
   shell: kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/bc79dd1505b0c8681ece4de4c0d86c5cd2643275/Documentation/kube-flannel.yml
 
 - name: get kubeconfig.conf from the master node
+  become: yes
   fetch:
     src: /etc/kubernetes/admin.conf
     dest: kubeconfig.conf
     flat: yes
 
 - name: replace the master node's internal/host network IP with floating IP
-  delegate_to: localhost
-  become: no
+  connection: local
   replace:
     path: '{{ playbook_dir }}/kubeconfig.conf'
     after: 'server:'

--- a/roles/openstack_infra/tasks/main.yml
+++ b/roles/openstack_infra/tasks/main.yml
@@ -3,6 +3,7 @@
     state: present
     name: manila-kube-security-group
     description: Security group with ingress to ports 22, 80, 443, 6443
+
 - name: add ssh ingress rule
   os_security_group_rule:
     state: present
@@ -10,6 +11,7 @@
     protocol: tcp
     port_range_min: 22
     port_range_max: 22
+
 - name: add http ingress rule
   os_security_group_rule:
     state: present
@@ -17,6 +19,7 @@
     protocol: tcp
     port_range_min: 80
     port_range_max: 80
+
 - name: add https ingress rule
   os_security_group_rule:
     state: present
@@ -24,6 +27,7 @@
     protocol: tcp
     port_range_min: 443
     port_range_max: 443
+
 - name: add ingress rule to kubernetes secure port
   os_security_group_rule:
     state: present
@@ -31,12 +35,14 @@
     protocol: tcp
     port_range_min: 6443
     port_range_max: 6443
+
 - name: allow icmp on the private cluster network
   os_security_group_rule:
     state: present
     security_group: manila-kube-security-group
     protocol: icmp
     remote_ip_prefix: 192.168.0.0/24
+
 - name: allow unrestricted TCP on the private cluster network
   os_security_group_rule:
     state: present
@@ -45,15 +51,18 @@
     port_range_min: 1
     port_range_max: 65535
     remote_ip_prefix: 192.168.0.0/24
+
 - name: create keypair
   os_keypair:
     state: present
     name: "{{ key_name }}"
     public_key_file: "{{ public_key_file }}"
+
 - name: create private network for the cluster
   os_network:
     state: present
     name: manila-kube-private-net
+
 - name: create private subnet on that network
   os_subnet:
     state: present
@@ -61,12 +70,14 @@
     name: manila-kube-private-subnet
     cidr: 192.168.0.0/24
     gateway_ip: 192.168.0.1
+
 - name: create router for the private network
   os_router:
     state: present
     name: manila-kube-private-router
     interfaces: manila-kube-private-subnet
     network: 38.145.32.0/22
+
 - name: launch master node
   os_server:
     name: master
@@ -79,15 +90,18 @@
     key_name: "{{ key_name }}"
     network: manila-kube-private-net
   register: master
+
 - name: add the master to our ansible inventory
   add_host: hostname="{{ master.server.public_v4 }}"
             groups=cluster,master
             ansible_ssh_private_key_file="{{private_key_file}}"
             ansible_ssh_user=centos
+
 - name: Create local login script
   template: src=login-master.sh.j2
             dest=./login-master.sh
             mode=0755
+
 - name: launch worker0
   os_server:
     name: worker0
@@ -100,15 +114,18 @@
     key_name: "{{ key_name }}"
     network: manila-kube-private-net
   register: worker0
+
 - name: add worker0 to our ansible inventory
   add_host: hostname="{{ worker0.server.public_v4 }}"
             groups=cluster,devstack,workers
             ansible_ssh_private_key_file="{{private_key_file}}"
             ansible_ssh_user=centos
+
 - name: Create local login script
   template: src=login-worker0.sh.j2
             dest=./login-worker0.sh
             mode=0755
+
 - name: launch worker1
   os_server:
     name: worker1
@@ -121,15 +138,18 @@
     key_name: "{{ key_name }}"
     network: manila-kube-private-net
   register: worker1
+
 - name: add worker1 to our ansible inventory
   add_host: hostname="{{ worker1.server.public_v4 }}"
             groups=cluster,workers
             ansible_ssh_private_key_file="{{private_key_file}}"
             ansible_ssh_user=centos
+
 - name: Create local login script
   template: src=login-worker1.sh.j2
             dest=./login-worker1.sh
             mode=0755
+
 - name: launch worker2
   os_server:
     name: worker2
@@ -142,15 +162,18 @@
     key_name: "{{ key_name }}"
     network: manila-kube-private-net
   register: worker2
+
 - name: add worker2 our ansible inventory
   add_host: hostname="{{ worker2.server.public_v4 }}"
             groups=cluster,workers
             ansible_ssh_private_key_file="{{ private_key_file }}"
             ansible_ssh_user=centos
+
 - name: Create local login script
   template: src=login-worker2.sh.j2
             dest=login-worker2.sh
             mode=0755
+
 - name: Print our ansible inventory groups
   vars:
     msg: |

--- a/roles/workers/tasks/main.yml
+++ b/roles/workers/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: join with master
+  become: yes
   command: kubeadm join --ignore-preflight-errors=cri --discovery-token-unsafe-skip-ca-verification --token={{ kubernetes_token }} {{ hostvars[groups['master'][0]].ansible_default_ipv4.address }}:6443
   args:
     creates: /etc/kubernetes/bootstrap-kubelet.conf

--- a/site.yml
+++ b/site.yml
@@ -10,16 +10,12 @@
 
 - hosts: cluster
   gather_facts: false
-  become: yes
-  become_method: sudo
   vars_files:
     - "global_vars.yml"
   roles:
     - cluster
 
 - hosts: master
-  become: yes
-  become_method: sudo
   vars_files:
     - "global_vars.yml"
   roles:
@@ -29,8 +25,6 @@
     KUBECONFIG: '/etc/kubernetes/admin.conf'
 
 - hosts: workers
-  become: yes
-  become_method: sudo
   vars_files:
     - "global_vars.yml"
   roles:


### PR DESCRIPTION
Instead of assuming sudo permissions on the entire
playbook, request privilege escalation only
when necessary. This way is more secure for all
hosts involved.

Change also includes some whitespace fixes between tasks